### PR TITLE
Change plant age display format to include months or days too (e.g. instead of "2 Years" something like "1 year, 9 months" or "1 month, 1 day", etc.)

### DIFF
--- a/PlantMama/DetailsView.swift
+++ b/PlantMama/DetailsView.swift
@@ -20,7 +20,7 @@ struct DetailsView: View {
                 VStack{
                         DetailsRow(label: "Name", value: plant.name)
                             .padding(5)
-                    DetailsRow(label: "Age", value: String(format: "%.f", age(yearPurchased: plant.datePurChased))+" Years" )
+                        DetailsRow(label: "Age", value: ageFormatted(datePurchased: plant.datePurChased))
                             .padding(5)
                         DetailsRow(label: "Type", value: plant.type)
                             .padding(5)
@@ -75,11 +75,15 @@ struct DetailsRowScroll: View {
     }
 }
 
-func age(yearPurchased: Date) -> Double {
-    let components = Calendar.current.dateComponents([.month], from: yearPurchased, to: Date())
-    guard let months = components.month else { return 0.0 }
-    return Double(months)/12.0
-    
+func ageFormatted(datePurchased: Date) -> String {
+    let ageFormatter = DateComponentsFormatter()
+    // Set the units we want to potentially display
+    ageFormatter.allowedUnits = [.year, .month, .day]
+    // Specify that we want the units to be provided in a full style (e.g., "1 year, 9 months")
+    ageFormatter.unitsStyle = .full
+    // Only show at most two of the units (e.g. "1 year, 9 months", "1 month, 1 day", etc.)
+    ageFormatter.maximumUnitCount = 2
+    return ageFormatter.string(from: datePurchased, to: Date()) ?? "Unknown"
 }
 
 #Preview(traits: .plantSampleData) {


### PR DESCRIPTION
Something I was putzing with yesterday at Bandit but couldn't quite finish before I left, haha.

Given an example of a plant date purchased = 2024-05-07 and current date = 2026-02-19:

Before this change it'd round the age to the nearest year ("2 Years"):

<img width="358" height="137" alt="before" src="https://github.com/user-attachments/assets/3c7d5f55-6989-400c-a347-cf488aa4eb71" />

After this change it'll show year + month level of detail like "1 year, 9 months" instead (or even month + day if the duration is small enough):

<img width="363" height="140" alt="after" src="https://github.com/user-attachments/assets/9f145d36-bda7-4c2a-9ca5-ad8e8fbcfae3" />

Feel free to reject/close the PR if you don't want this change. I just figured I'd offer it if's a change you want to take since I did end up finishing it today (with ChatGPT's help).